### PR TITLE
[TASK] Set cache tags for related news in detail action

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -409,7 +409,7 @@ class NewsController extends NewsBaseController
 
         if ($news !== null) {
             Page::setRegisterProperties($this->settings['detail']['registerProperties'] ?? false, $news);
-            Cache::addCacheTagsByNewsRecords([$news]);
+            Cache::addCacheTagsByNewsRecords([$news, ...$news->getRelated()->toArray()]);
 
             if ($this->settings['detail']['pageTitle']['_typoScriptNodeValue'] ?? false) {
                 $providerConfiguration = $this->settings['detail']['pageTitle'] ?? [];


### PR DESCRIPTION
When the title of a related news entry changes, you want the cache of the detail action flushed to display the updated title