### PR TITLE
[FEATURE] Add NewsDemandFactory to build demands outside the controller

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -15,7 +15,6 @@ use GeorgRinger\News\Domain\Model\News;
 use GeorgRinger\News\Domain\Repository\CategoryRepository;
 use GeorgRinger\News\Domain\Repository\NewsRepository;
 use GeorgRinger\News\Domain\Repository\TagRepository;
-use GeorgRinger\News\Event\CreateDemandObjectFromSettingsEvent;
 use GeorgRinger\News\Event\NewsCheckPidOfNewsRecordFailedInDetailActionEvent;
 use GeorgRinger\News\Event\NewsControllerOverrideSettingsEvent;
 use GeorgRinger\News\Event\NewsDateMenuActionEvent;
@@ -27,6 +26,7 @@ use GeorgRinger\News\Event\NewsSearchFormActionEvent;
 use GeorgRinger\News\Event\NewsSearchResultActionEvent;
 use GeorgRinger\News\Pagination\QueryResultPaginator;
 use GeorgRinger\News\Seo\NewsTitleProvider;
+use GeorgRinger\News\Service\NewsDemandFactory;
 use GeorgRinger\News\Utility\Cache;
 use GeorgRinger\News\Utility\ClassCacheManager;
 use GeorgRinger\News\Utility\TypoScript;
@@ -56,6 +56,8 @@ class NewsController extends NewsBaseController
 
     protected TagRepository $tagRepository;
 
+    protected NewsDemandFactory $newsDemandFactory;
+
     /** @var array */
     protected $ignoredSettingsForOverride = ['demandclass', 'orderbyallowed', 'selectedList'];
 
@@ -69,11 +71,13 @@ class NewsController extends NewsBaseController
     public function __construct(
         NewsRepository $newsRepository,
         CategoryRepository $categoryRepository,
-        TagRepository $tagRepository
+        TagRepository $tagRepository,
+        NewsDemandFactory $newsDemandFactory
     ) {
         $this->newsRepository = $newsRepository;
         $this->categoryRepository = $categoryRepository;
         $this->tagRepository = $tagRepository;
+        $this->newsDemandFactory = $newsDemandFactory;
     }
 
     /**
@@ -102,63 +106,15 @@ class NewsController extends NewsBaseController
      * Create the demand object which define which records will get shown
      *
      * @param string $class optional class which must be an instance of \GeorgRinger\News\Domain\Model\Dto\NewsDemand
+     * @deprecated since 14.1, use \GeorgRinger\News\Service\NewsDemandFactory::create() instead. The method is
+     *             still called internally so that existing overrides keep working, but new code should use the
+     *             factory or the \GeorgRinger\News\Event\CreateDemandObjectFromSettingsEvent.
      */
     protected function createDemandObjectFromSettings(
         array $settings,
         $class = NewsDemand::class
     ): NewsDemand {
-        $class = isset($settings['demandClass']) && !empty($settings['demandClass']) ? $settings['demandClass'] : $class;
-
-        /* @var $demand NewsDemand */
-        if (!is_a($class, NewsDemand::class, true)) {
-            throw new \UnexpectedValueException(
-                sprintf(
-                    'The demand object must be an instance of %s, but %s given!',
-                    NewsDemand::class,
-                    $class
-                ),
-                1423157953
-            );
-        }
-        /* @var $demand NewsDemand */
-        $demand = GeneralUtility::makeInstance($class, $settings);
-
-        $demand->setCategories(GeneralUtility::trimExplode(',', $settings['categories'] ?? '', true));
-        $demand->setCategoryConjunction((string)($settings['categoryConjunction'] ?? ''));
-        $demand->setIncludeSubCategories((bool)($settings['includeSubCategories'] ?? false));
-        $demand->setTags((string)($settings['tags'] ?? ''));
-
-        $demand->setTopNewsRestriction((int)($settings['topNewsRestriction'] ?? 0));
-        $demand->setTimeRestriction($settings['timeRestriction'] ?? '');
-        $demand->setTimeRestrictionHigh($settings['timeRestrictionHigh'] ?? '');
-        $demand->setArchiveRestriction((string)($settings['archiveRestriction'] ?? ''));
-        $demand->setExcludeAlreadyDisplayedNews((bool)($settings['excludeAlreadyDisplayedNews'] ?? false));
-        $demand->setHideIdList((string)($settings['hideIdList'] ?? ''));
-
-        if ($settings['orderBy'] ?? '') {
-            $demand->setOrder($settings['orderBy'] . ' ' . $settings['orderDirection']);
-        }
-        $demand->setOrderByAllowed((string)($settings['orderByAllowed'] ?? ''));
-
-        $demand->setTopNewsFirst((bool)($settings['topNewsFirst'] ?? false));
-
-        $demand->setLimit((int)($settings['limit'] ?? 0));
-        $demand->setOffset((int)($settings['offset'] ?? 0));
-
-        $demand->setSearchFields((string)($settings['search']['fields'] ?? ''));
-        $demand->setDateField((string)($settings['dateField'] ?? ''));
-        $demand->setMonth((int)($settings['month'] ?? 0));
-        $demand->setYear((int)($settings['year'] ?? 0));
-
-        $pageRepository = GeneralUtility::makeInstance(PageRepository::class);
-        $idList = $pageRepository->getPageIdsRecursive(GeneralUtility::intExplode(',', (string)($settings['startingpoint'] ?? '')), (int)($settings['recursive'] ?? 0));
-        $demand->setStoragePage(implode(',', $idList));
-
-        $event = new CreateDemandObjectFromSettingsEvent($demand, $settings, $class);
-        $this->eventDispatcher->dispatch($event);
-        $demand = $event->getDemand();
-
-        return $demand;
+        return $this->newsDemandFactory->create($settings, $class);
     }
 
     /**

--- a/Classes/Service/NewsDemandFactory.php
+++ b/Classes/Service/NewsDemandFactory.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace GeorgRinger\News\Service;
+
+use GeorgRinger\News\Domain\Model\Dto\NewsDemand;
+use GeorgRinger\News\Event\CreateDemandObjectFromSettingsEvent;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Domain\Repository\PageRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Creates demand objects out of a settings array, e.g. the TypoScript settings
+ * of a news plugin.
+ *
+ * Use this service whenever news records need to be fetched outside of the
+ * NewsController, for example in a custom controller, a ViewHelper, a
+ * DataProcessor or an API endpoint.
+ */
+class NewsDemandFactory
+{
+    public function __construct(
+        protected readonly EventDispatcherInterface $eventDispatcher
+    ) {}
+
+    /**
+     * Create the demand object which defines which records will get shown
+     *
+     * @param array $settings settings of the plugin, e.g. plugin.tx_news.settings
+     * @param string $class optional class which must be an instance of \GeorgRinger\News\Domain\Model\Dto\NewsDemand
+     */
+    public function create(array $settings, string $class = NewsDemand::class): NewsDemand
+    {
+        $class = isset($settings['demandClass']) && !empty($settings['demandClass']) ? $settings['demandClass'] : $class;
+
+        if (!is_a($class, NewsDemand::class, true)) {
+            throw new \UnexpectedValueException(
+                sprintf(
+                    'The demand object must be an instance of %s, but %s given!',
+                    NewsDemand::class,
+                    $class
+                ),
+                1423157953
+            );
+        }
+        /* @var $demand NewsDemand */
+        $demand = GeneralUtility::makeInstance($class, $settings);
+
+        $demand->setCategories(GeneralUtility::trimExplode(',', $settings['categories'] ?? '', true));
+        $demand->setCategoryConjunction((string)($settings['categoryConjunction'] ?? ''));
+        $demand->setIncludeSubCategories((bool)($settings['includeSubCategories'] ?? false));
+        $demand->setTags((string)($settings['tags'] ?? ''));
+
+        $demand->setTopNewsRestriction((int)($settings['topNewsRestriction'] ?? 0));
+        $demand->setTimeRestriction($settings['timeRestriction'] ?? '');
+        $demand->setTimeRestrictionHigh($settings['timeRestrictionHigh'] ?? '');
+        $demand->setArchiveRestriction((string)($settings['archiveRestriction'] ?? ''));
+        $demand->setExcludeAlreadyDisplayedNews((bool)($settings['excludeAlreadyDisplayedNews'] ?? false));
+        $demand->setHideIdList((string)($settings['hideIdList'] ?? ''));
+
+        if ($settings['orderBy'] ?? '') {
+            $demand->setOrder($settings['orderBy'] . ' ' . $settings['orderDirection']);
+        }
+        $demand->setOrderByAllowed((string)($settings['orderByAllowed'] ?? ''));
+
+        $demand->setTopNewsFirst((bool)($settings['topNewsFirst'] ?? false));
+
+        $demand->setLimit((int)($settings['limit'] ?? 0));
+        $demand->setOffset((int)($settings['offset'] ?? 0));
+
+        $demand->setSearchFields((string)($settings['search']['fields'] ?? ''));
+        $demand->setDateField((string)($settings['dateField'] ?? ''));
+        $demand->setMonth((int)($settings['month'] ?? 0));
+        $demand->setYear((int)($settings['year'] ?? 0));
+
+        $pageRepository = GeneralUtility::makeInstance(PageRepository::class);
+        $idList = $pageRepository->getPageIdsRecursive(GeneralUtility::intExplode(',', (string)($settings['startingpoint'] ?? '')), (int)($settings['recursive'] ?? 0));
+        $demand->setStoragePage(implode(',', $idList));
+
+        $event = new CreateDemandObjectFromSettingsEvent($demand, $settings, $class);
+        $this->eventDispatcher->dispatch($event);
+
+        return $event->getDemand();
+    }
+}

--- a/Documentation/Tutorials/ExtendNews/Demands/Index.rst
+++ b/Documentation/Tutorials/ExtendNews/Demands/Index.rst
@@ -56,6 +56,67 @@ extending EXT:news. Read more about using a demand object in a custom
 controller:
 :ref:`Extension based on EXT:news: FilterController.php <extension_custom_controller>`.
 
+.. _demand_factory:
+
+Building a demand outside of a controller
+=========================================
+
+The service :php:`GeorgRinger\News\Service\NewsDemandFactory` turns a settings
+array - typically the TypoScript settings of a news plugin - into a demand
+object. Use it whenever news records have to be fetched outside of the
+:php:`NewsController`, for example in a ViewHelper, a DataProcessor, a
+middleware or an API endpoint.
+
+The service applies the same rules as the plugin does: it respects
+:ref:`settings.demandClass <tsDemandClass>`, resolves
+:code:`settings.startingpoint` and :code:`settings.recursive` into the storage
+page list and dispatches the
+:php:`\GeorgRinger\News\Event\CreateDemandObjectFromSettingsEvent`. Listeners
+registered for that event therefore also apply to demands built this way.
+
+.. code-block:: php
+
+   <?php
+
+   namespace Vendor\MyNews\Api;
+
+   use GeorgRinger\News\Domain\Repository\NewsRepository;
+   use GeorgRinger\News\Service\NewsDemandFactory;
+
+   class LatestNewsProvider
+   {
+      public function __construct(
+         private readonly NewsDemandFactory $newsDemandFactory,
+         private readonly NewsRepository $newsRepository
+      ) {}
+
+      public function findLatest(int $storagePid): array
+      {
+         $demand = $this->newsDemandFactory->create([
+            'startingpoint' => (string)$storagePid,
+            'orderBy' => 'datetime',
+            'orderDirection' => 'desc',
+            'limit' => 5,
+         ]);
+
+         return $this->newsRepository->findDemanded($demand)->toArray();
+      }
+   }
+
+The second, optional argument of :php:`create()` defines the demand class to
+use when the settings contain no :code:`demandClass` key:
+
+.. code-block:: php
+
+   $demand = $this->newsDemandFactory->create($settings, MyNewsDemand::class);
+
+.. note::
+
+   The protected method :php:`NewsController::createDemandObjectFromSettings()`
+   is deprecated since version 14.1 and only delegates to this service. Custom
+   controllers extending :php:`NewsController` should use the factory or the
+   :php:`CreateDemandObjectFromSettingsEvent` instead of overriding it.
+
 Events
 ======
 

--- a/Tests/Unit/Service/Fixtures/CustomNewsDemandFixture.php
+++ b/Tests/Unit/Service/Fixtures/CustomNewsDemandFixture.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace GeorgRinger\News\Tests\Unit\Service\Fixtures;
+
+use GeorgRinger\News\Domain\Model\Dto\NewsDemand;
+
+class CustomNewsDemandFixture extends NewsDemand {}

--- a/Tests/Unit/Service/NewsDemandFactoryTest.php
+++ b/Tests/Unit/Service/NewsDemandFactoryTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace GeorgRinger\News\Tests\Unit\Service;
+
+use GeorgRinger\News\Domain\Model\Dto\NewsDemand;
+use GeorgRinger\News\Event\CreateDemandObjectFromSettingsEvent;
+use GeorgRinger\News\Service\NewsDemandFactory;
+use GeorgRinger\News\Tests\Unit\Service\Fixtures\CustomNewsDemandFixture;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Domain\Repository\PageRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\BaseTestCase;
+
+/**
+ * Test class for NewsDemandFactory
+ */
+class NewsDemandFactoryTest extends BaseTestCase
+{
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        parent::tearDown();
+    }
+
+    #[DataProvider('settingsAreMappedToTheDemandDataProvider')]
+    #[Test]
+    public function settingsAreMappedToTheDemand(array $settings, string $getter, mixed $expected): void
+    {
+        $demand = $this->buildSubject()->create($settings);
+
+        self::assertSame($expected, $demand->{$getter}());
+    }
+
+    public static function settingsAreMappedToTheDemandDataProvider(): array
+    {
+        return [
+            'categories are split into an array' => [
+                ['categories' => '1, 2 ,3'], 'getCategories', ['1', '2', '3'],
+            ],
+            'empty categories result in an empty array' => [
+                [], 'getCategories', [],
+            ],
+            'category conjunction is taken over' => [
+                ['categoryConjunction' => 'or'], 'getCategoryConjunction', 'or',
+            ],
+            'sub categories are cast to bool' => [
+                ['includeSubCategories' => '1'], 'getIncludeSubCategories', true,
+            ],
+            'tags are taken over' => [
+                ['tags' => '4,5'], 'getTags', '4,5',
+            ],
+            'top news restriction is cast to int' => [
+                ['topNewsRestriction' => '2'], 'getTopNewsRestriction', 2,
+            ],
+            'archive restriction is taken over' => [
+                ['archiveRestriction' => 'active'], 'getArchiveRestriction', 'active',
+            ],
+            'already displayed news flag is cast to bool' => [
+                ['excludeAlreadyDisplayedNews' => '1'], 'getExcludeAlreadyDisplayedNews', true,
+            ],
+            'hide id list is taken over' => [
+                ['hideIdList' => '7,8'], 'getHideIdList', '7,8',
+            ],
+            'order is combined out of field and direction' => [
+                ['orderBy' => 'datetime', 'orderDirection' => 'desc'], 'getOrder', 'datetime desc',
+            ],
+            'order stays empty without an order field' => [
+                ['orderBy' => '', 'orderDirection' => 'desc'], 'getOrder', '',
+            ],
+            'allowed order fields are taken over' => [
+                ['orderByAllowed' => 'title,datetime'], 'getOrderByAllowed', 'title,datetime',
+            ],
+            'top news first is cast to bool' => [
+                ['topNewsFirst' => '1'], 'getTopNewsFirst', true,
+            ],
+            'limit is cast to int' => [
+                ['limit' => '10'], 'getLimit', 10,
+            ],
+            'offset is cast to int' => [
+                ['offset' => '5'], 'getOffset', 5,
+            ],
+            'search fields are read from the nested search settings' => [
+                ['search' => ['fields' => 'title,teaser']], 'getSearchFields', 'title,teaser',
+            ],
+            'date field is taken over' => [
+                ['dateField' => 'datetime'], 'getDateField', 'datetime',
+            ],
+            'month is cast to int' => [
+                ['month' => '3'], 'getMonth', 3,
+            ],
+            'year is cast to int' => [
+                ['year' => '2026'], 'getYear', 2026,
+            ],
+        ];
+    }
+
+    #[Test]
+    public function storagePageIsResolvedRecursively(): void
+    {
+        $pageRepository = $this->createMock(PageRepository::class);
+        $pageRepository->expects(self::once())
+            ->method('getPageIdsRecursive')
+            ->with([1, 2], 3)
+            ->willReturn([1, 2, 10, 11]);
+
+        $demand = $this->buildSubject($pageRepository)->create([
+            'startingpoint' => '1,2',
+            'recursive' => '3',
+        ]);
+
+        self::assertSame('1,2,10,11', $demand->getStoragePage());
+    }
+
+    #[Test]
+    public function demandClassFromSettingsIsUsed(): void
+    {
+        $demand = $this->buildSubject()->create(['demandClass' => CustomNewsDemandFixture::class]);
+
+        self::assertInstanceOf(CustomNewsDemandFixture::class, $demand);
+    }
+
+    #[Test]
+    public function demandClassArgumentIsUsedIfSettingsDoNotDefineOne(): void
+    {
+        $demand = $this->buildSubject()->create([], CustomNewsDemandFixture::class);
+
+        self::assertInstanceOf(CustomNewsDemandFixture::class, $demand);
+    }
+
+    #[Test]
+    public function demandClassFromSettingsTakesPrecedenceOverTheArgument(): void
+    {
+        $demand = $this->buildSubject()->create(
+            ['demandClass' => CustomNewsDemandFixture::class],
+            NewsDemand::class
+        );
+
+        self::assertInstanceOf(CustomNewsDemandFixture::class, $demand);
+    }
+
+    #[Test]
+    public function exceptionIsThrownForADemandClassNotExtendingNewsDemand(): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionCode(1423157953);
+
+        $this->buildSubject()->create(['demandClass' => \stdClass::class]);
+    }
+
+    #[Test]
+    public function eventIsDispatchedWithTheDemandTheSettingsAndTheClass(): void
+    {
+        $settings = ['limit' => '10', 'demandClass' => CustomNewsDemandFixture::class];
+        $dispatchedEvent = null;
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects(self::once())
+            ->method('dispatch')
+            ->willReturnCallback(static function (CreateDemandObjectFromSettingsEvent $event) use (&$dispatchedEvent) {
+                $dispatchedEvent = $event;
+                return $event;
+            });
+
+        $this->buildSubject(null, $eventDispatcher)->create($settings);
+
+        self::assertInstanceOf(CustomNewsDemandFixture::class, $dispatchedEvent->getDemand());
+        self::assertSame($settings, $dispatchedEvent->getSettings());
+        self::assertSame(CustomNewsDemandFixture::class, $dispatchedEvent->getClass());
+    }
+
+    #[Test]
+    public function demandReplacedByAnEventListenerIsReturned(): void
+    {
+        $replacement = new CustomNewsDemandFixture();
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->method('dispatch')
+            ->willReturnCallback(static function (CreateDemandObjectFromSettingsEvent $event) use ($replacement) {
+                $event->setDemand($replacement);
+                return $event;
+            });
+
+        $demand = $this->buildSubject(null, $eventDispatcher)->create([]);
+
+        self::assertSame($replacement, $demand);
+    }
+
+    protected function buildSubject(
+        ?PageRepository $pageRepository = null,
+        ?EventDispatcherInterface $eventDispatcher = null
+    ): NewsDemandFactory {
+        if ($pageRepository === null) {
+            $pageRepository = $this->createMock(PageRepository::class);
+            $pageRepository->method('getPageIdsRecursive')->willReturn([]);
+        }
+        GeneralUtility::addInstance(PageRepository::class, $pageRepository);
+
+        return new NewsDemandFactory($eventDispatcher ?? $this->createMock(EventDispatcherInterface::class));
+    }
+}


### PR DESCRIPTION
Building a NewsDemand from settings was only possible through the
protected NewsController::createDemandObjectFromSettings(), forcing
callers outside the plugin to either extend the controller or copy the
method.

The logic is moved as-is into GeorgRinger\News\Service\NewsDemandFactory.
The controller method is kept, still called from all actions and marked
deprecated, so subclass overrides are unaffected.